### PR TITLE
Admin Add and Delete Tests

### DIFF
--- a/src/components/Admin/TestManager.js
+++ b/src/components/Admin/TestManager.js
@@ -10,12 +10,11 @@ export const TestManager = () => {
     const [tests, setTests] = useState([])
     const [newInfo, setNewInfo] = useState(false)
     const alertNewInfo = () => setNewInfo(!newInfo)
+    const [confirm, setConfirm] = useState(false)
+    const toggleConfirm = () => setConfirm(!confirm)
+    const [testId, setTestId] = useState(0)
 
-    const [newTest, setNewTest] = useState({
-        "name": "",
-        "year": "",
-        "numSci": 0
-    })
+ 
     const [form, setForm] = useState(false)
     const toggleForm = () => setForm(!form)
 
@@ -25,15 +24,13 @@ export const TestManager = () => {
 
     }, [newInfo])
 
-    const handleInputChange = (event) => {
-        const copy = {...newTest}
-        const name = event.target.name
-        if (name === "name") {
-            copy.name = event.target.value
-        } else {
-            copy.name = parseInt(event.target.value)
+    const deleteTest = () => {
+        if (testId) {
+            TestRepository.delete(parseInt(testId)).then(() => {
+                alertNewInfo()
+                toggleConfirm()
+            })
         }
-        setNewTest(copy)
     }
 
     return (<>
@@ -46,7 +43,10 @@ export const TestManager = () => {
                     tests.map((test) => {
                         return <div key={test.id}>
                             {test.name} ({test.year})
-                            <button><Delete /></button>
+                            <button><Delete onClick={() => {
+                                setTestId(test.id)
+                                toggleConfirm()
+                            }} /></button>
                         </div>
                     })
                 }
@@ -60,9 +60,15 @@ export const TestManager = () => {
                 isOpen={form}>
                 <ModalHeader>Add Test</ModalHeader>
                 <ModalBody>
-                    <TestForm toggleForm={toggleForm}/>
+                    <TestForm toggleForm={toggleForm} alertNewInfo={alertNewInfo}/>
                 </ModalBody>
             </Modal>
+
+            <Dialog open={confirm} toggle={toggleConfirm}>
+            Are You Sure?
+            <Button onClick={deleteTest}>Yes, Delete</Button>
+            <Button onClick={toggleConfirm}>Cancel</Button>
+        </Dialog>
 
         </div>
 

--- a/src/components/Forms/TestForm.js
+++ b/src/components/Forms/TestForm.js
@@ -1,42 +1,69 @@
-import { Button, DialogContent, Input, Radio } from '@material-ui/core';
-import { Delete } from '@material-ui/icons';
+import { Form, InputGroup, InputGroupText, Input, Button } from 'reactstrap';
+
 import React, { useEffect, useState } from "react"
+import { FormControlLabel, Radio, RadioGroup } from '@material-ui/core';
+import TestRepository from '../../repositories/TestRepository';
 
 
-export const TestForm = ({edit, toggleForm}) => {
-    const [newInfo, setNewInfo] = useState(false)
-    const alertNewInfo = () => setNewInfo(!newInfo)
-
+export const TestForm = ({ toggleForm, alertNewInfo }) => {
     const [test, setTest] = useState({
         "name": "",
         "year": "",
         "numSci": 0
     })
 
-    const handleInputChange = (event) => {
-        //! NOT WORKING YET - NEED TO REMEMBER HOW TO USE useRefs for change-handling
-        const copy = { ...test }
-        const name = event.target.name
-        if (name === "name") {
-            copy.name = event.target.value
-        } else {
-            copy.name = parseInt(event.target.value)
+    const addTest = () => {
+        if (test.name && test.year && test.numSci) {
+            TestRepository.add(test).then(() => {
+                alertNewInfo()
+                toggleForm()
+            })
         }
-        setTest(copy)
     }
 
     return (
 
-        <DialogContent className="">
-            <Input className="" type="text" name="name" defaultValue={test.name} placeholder="Name" onChange={handleInputChange}></Input>
-            <Input className="" type="text" name="year" defaultValue={test.year} placeholder="Year" onChange={handleInputChange}></Input>
-            <Radio name="numSci" value="6" color="default" onChange={handleInputChange} />
-            <Radio name="numSci" value="7" color="default" onChange={handleInputChange} />
+        <Form className="">
+            <InputGroup>
+                <InputGroupText>Test Name</InputGroupText>
+                <Input className="" type="text" name="name" defaultValue={test.name} placeholder="Name"
+                    onChange={(e) => {
+                        const copy = { ...test }
+                        copy.name = e.target.value
+                        setTest(copy)
+                    }}>
+                </Input>
+            </InputGroup>
+            <InputGroup>
+                <InputGroupText>Test Year</InputGroupText>
+                <Input className="" type="text" name="year" defaultValue={test.year} placeholder="Year"
+                    onChange={(e) => {
+                        const copy = { ...test }
+                        copy.year = parseInt(e.target.value)
+                        setTest(copy)
+                    }}>
+                </Input>
+            </InputGroup>
+
+            <InputGroup>
+                <InputGroupText>Num Science Sections</InputGroupText>
+                <RadioGroup row aria-labelledby="demo-row-radio-buttons-group-label" name="row-radio-buttons-group"
+                    onChange={(e) => {
+                        const copy = { ...test }
+                        copy.numSci = parseInt(e.target.value)
+                        setTest(copy)
+                    }}>
+                    <FormControlLabel value="6" control={<Radio />} label="6" />
+                    <FormControlLabel value="7" control={<Radio />} label="7" />
+                </RadioGroup>
+
+            </InputGroup>
+
             <div className="">
-                <div className=""><Button className="" variant="outlined" onClick={() => { }}>{edit? "Update" : "Add"}</Button></div>
+                <div className=""><Button className="" variant="outlined" onClick={addTest}>Add</Button></div>
                 <div className=""><Button className="" variant="outlined" onClick={toggleForm}>Cancel</Button></div>
             </div>
-        </DialogContent>
+        </Form>
 
 
     )

--- a/src/repositories/TestRepository.js
+++ b/src/repositories/TestRepository.js
@@ -20,7 +20,7 @@ const TestRepository = {
     },
 
     async delete(id) {
-        return await fetchIt(`${Settings.remoteURL}/tests${id}`, "DELETE")
+        return await fetchIt(`${Settings.remoteURL}/tests/${id}`, "DELETE")
     },
 
 }


### PR DESCRIPTION
Description of Changes:
From Test Manager page, admin can add and delete tests
- Clicking on add test button prompts a modal to open with the new test form
- Clicking on the trash icon next to a test will ask for confirmation before removing that test from the database (and list)
- Tests are also now ordered by year desc

Does this request support or fix an existing issue?
Fixes #12 
Fixes #13 